### PR TITLE
add interface in patch test case

### DIFF
--- a/gopbuild/build_test.go
+++ b/gopbuild/build_test.go
@@ -430,10 +430,22 @@ func main() {
 
 func TestPackagePatch(t *testing.T) {
 	ctx := igop.NewContext(0)
+	err := ctx.AddImportFile("github.com/qiniu/x/gsh", "src.go", `package gsh
+type Foo interface {
+	Bar() int
+}
+type App struct {}
+func (f *App) Bar() int {
+	return 1
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
 	RegisterPackagePatch(ctx, "github.com/qiniu/x/gsh", `package gsh
 import "github.com/qiniu/x/gsh"
 
-func Gopt_App_Gopx_GetWidget[T any](app any, name string) {
+func Gopt_App_Gopx_GetWidget[T any](app gsh.Foo, name string) {
 	var _ gsh.App
 	println(app, name)
 }


### PR DESCRIPTION
```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestPackagePatch$ github.com/goplus/igop/gopbuild

--- FAIL: TestPackagePatch (0.01s)
    /Users/nighca/code/goplus/igop/gopbuild/build_test.go:479: -: cannot use  (type *App) as type github.com/qiniu/x/gsh.Foo in argument to getWidget(int,"info")
FAIL
FAIL	github.com/goplus/igop/gopbuild	0.517s
FAIL

```